### PR TITLE
chore: not found file default is empty object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ class Horae<T extends Object> {
       );
       this.config.data = data;
     } else {
-      throw new Error(`[Error]: Not found file`);
+      this.config.data = {} as T;
     }
   }
 


### PR DESCRIPTION
## Summary

- default is empty object if not found file
